### PR TITLE
Improve readme by fixing typo (Change "Websocket's" to "Websockets")

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ A real-time collaborative pixel art canvas where users can draw pixels and see l
   - HTML5 Canvas
 - Backend
   - Go
-  - Websocket's
+  - Websockets
 - Data storage
   - Redis


### PR DESCRIPTION
- Improve readme by fixing typo (Change "Websocket's" to "Websockets")

Explanation:
Apostrophes are generally used for possessive forms or contractions, not for making words plural. I've corrected this in the text to reflect the proper plural form!

Awesome project by the way 💯 
@joshuarichards001 